### PR TITLE
update plan in readme

### DIFF
--- a/.github/workflows/test-feature-branches.yml
+++ b/.github/workflows/test-feature-branches.yml
@@ -39,8 +39,8 @@ jobs:
         continue-on-error: true
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
-          files: ./coverage.xml
-          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: khaldoun-xyz/ml_api
         continue-on-error: true

--- a/.github/workflows/test-feature-branches.yml
+++ b/.github/workflows/test-feature-branches.yml
@@ -37,10 +37,3 @@ jobs:
       - name: Generate coverage report
         run: pixi run -e dev test-cov
         continue-on-error: true
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: khaldoun-xyz/ml_api
-        continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ to develop the loan application algorithm.
 | Phase | Tasks & Components |
 | :--- | :--- |
 | **Plan** | - well-reasoned product specification<br> - transparent repo structure |
-| **Developing the model** | - managing the terminal<br>- source control with git<br>- environment mgmt. with pixi<br>- EDA with Jupyter Notebook<br>- model tracking with MLFlow |
-| **Serving the model** | - web service & REST endpoint with FastAPI<br>- data validation with pydantic<br>- containerisation with docker |
-| **Integrating the model** | - legacy IT system calls API<br>- monitoring with Grafana |
+| **Developing the model** | - environment mgmt. with pixi<br>- EDA with Jupyter Notebook<br>- model tracking with MLFlow |
+| **Serving the model** | - web service & REST endpoint with FastAPI<br>- data validation with pydantic<br>- containerisation with docker<br>- creating a network between containers<br>- automated tests with pytest & Github Actions |
+| **Integrating the model** | - legacy IT system calls API<br>- monitoring with Prometheus & Grafana |
 
 ### Development flow
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ to develop the loan application algorithm.
 | :--- | :--- |
 | **Plan** | - well-reasoned product specification<br> - transparent repo structure |
 | **Developing the model** | - environment mgmt. with pixi<br>- EDA with Jupyter Notebook<br>- model tracking with MLFlow |
-| **Serving the model** | - web service & REST endpoint with FastAPI<br>- data validation with pydantic<br>- containerisation with docker<br>- creating a network between containers<br>- automated tests with pytest & Github Actions |
+| **Serving the model** | - web service & REST endpoint with FastAPI<br>- data validation with pydantic<br>- containerisation with docker<br>- creating a network between containers<br>- automated tests with pytest & GitHub Actions |
 | **Integrating the model** | - legacy IT system calls API<br>- monitoring with Prometheus & Grafana |
 
 ### Development flow


### PR DESCRIPTION
This pull request updates the project plan in the `README.md` to better reflect the current tech stack and workflow. The main changes clarify tooling choices, add missing steps, and improve accuracy around monitoring and testing.

Updates to development and integration workflow:

* Removed "managing the terminal" and "source control with git" from the "Developing the model" phase, focusing this phase on environment management, EDA, and model tracking.
* Added "creating a network between containers" and "automated tests with pytest & Github Actions" to the "Serving the model" phase to highlight deployment and CI/CD practices.
* Updated monitoring in the "Integrating the model" phase to include "Prometheus & Grafana" instead of just "Grafana", reflecting a more complete observability stack.